### PR TITLE
add "Avoid `.ready()`" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jQuery's [`.ready()`](https://api.jquery.com/ready/) ensures your script is not 
 ### How?
 
 Avoid loading scripts too early and waiting for the DOM to be ready using `.ready()`.
-Defer script loading by placing scripts just before the closing `</body>` tag or using the `defer` attribute:
+Defer script loading by placing scripts just before the closing `</body>` tag or using the [`defer` attribute](https://developer.mozilla.org/en/docs/Web/HTML/Element/script#attr-defer):
 
 ```html
 <!-- recommended: load in tail -->
@@ -55,6 +55,8 @@ Defer script loading by placing scripts just before the closing `</body>` tag or
 	<script defer src="path/to/my-app.min.js"></script>
 </head>
 ```
+
+Note: Be aware [using `defer` in IE <= 9 can cause issues](https://github.com/h5bp/lazyweb-requests/issues/42). So consider your browser scope before using this setup.
 
 ```html
 <!-- avoid: -->

--- a/README.md
+++ b/README.md
@@ -16,8 +16,54 @@ This guide aims to improve the way your team uses [jQuery](http://jquery.com/). 
 ## Table of Contents
 
 * [About jQuery](#about-jquery)
+* [Avoid `.ready()`](#avoid-ready)
 
 
 ## About jQuery
 
 [jQuery](http://jquery.com/) is a utility library for easy DOM access & manipulation, event handling, Ajax and more. By using jQuery you can write consise and expressive code which works across modern and legacy browsers. jQuery has extensive tests, detailed documentation, a large active community and an ecosystem of plugins.
+
+
+## Avoid `.ready()`
+
+jQuery's [`.ready()`](https://api.jquery.com/ready/) ensures your script is not executed before the DOM is ready. This is important because we typically want to access the DOM in our script. However, since the script can't be executed before the DOM is ready, a better practice is to defer script execution.
+
+### Why?
+
+* Using `.ready()` means scripts have been loaded too early. Therefore defer loading instead.
+* Script loading blocks page rendering. Therefore script loading should be defered. 
+
+### How?
+
+Avoid loading scripts too early and waiting for the DOM to be ready using `.ready()`.
+Defer script loading by placing scripts just before the closing `</body>` tag or using the `defer` attribute:
+
+```html
+<!-- recommended: load in tail -->
+<body>
+   ...
+	<script src="path/to/jquery.min.js"></script>
+	<script>/* DOM is ready, use jQuery directly */</script>
+</body>
+```
+
+```html
+<!-- recommended: defer script loading -->
+<head>
+	...
+	<script defer src="path/to/jquery.min.js"></script>
+	<script defer src="path/to/my-app.min.js"></script>
+</head>
+```
+
+```html
+<!-- avoid: -->
+<head>
+	...
+	<script src="path/to/jquery.min.js"></script>
+	<script>jQuery.ready(function(){ /* ... */ });</script>
+	<!-- same applies to external script containing `.ready()` -->
+</head>
+```
+
+[↑ back to Table of Contents](#table-of-contents)


### PR DESCRIPTION
incl summary, why and how with examples.
