### PR TITLE
Update "Use `.on()`" with "event delegation" argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Methods like [`.click()`](http://api.jquery.com/click/) or [`.change()`](http://
 
 ### Why?
 
+* `.on()` supports [event delegation](http://api.jquery.com/on/#direct-and-delegated-events) resulting in more flexibility and better performance.
 * It's a way to keep consistency as all your events have the same signature.
 * Avoiding using aliases let you trim the jQuery custom build. That way you reduce load/parse times and the file size.
 


### PR DESCRIPTION
To me, that's the most important reason to use `.on()` instead of the aliases.

Note: When we have our own guideline for "Use event delegation with `.on()`" we can refer to that guideline instead of the jQuery docs.
